### PR TITLE
adding support for reading txt file dbs

### DIFF
--- a/src/code/include/par_db.hpp
+++ b/src/code/include/par_db.hpp
@@ -531,6 +531,7 @@ class ParDB : public PandoParticipant {
                 cerr << "[ERROR] directory " << dir << " did not exist" << endl;
             } else {
                 for (const auto & entry : std::filesystem::directory_iterator(dir)) {
+                    if (entry.is_directory()) continue;
                     auto& n_req = *n_it;
 
                     string full_fn = entry.path().string();
@@ -565,7 +566,12 @@ class ParDB : public PandoParticipant {
         }
 
         void import_db(string fn) {
-            db_.import_db(fn);
+            string suffix = ".txt";
+            if (suffix == fn.substr(fn.length() - suffix.length(), fn.length())) {
+                db_.add_db_file(fn);
+            } else {
+                db_.import_db(fn);
+            }
         }
 
         /** @brief Begin waiting for a barrier */

--- a/src/code/test/test_par_db.cpp
+++ b/src/code/test/test_par_db.cpp
@@ -1067,6 +1067,28 @@ TEST(query_multiple_tags) {
 
 }
 
+TEST(import_txt_db) {
+    elga::ZMQAddress db1_addr { "127.0.0.1", g_idx+=inc_amount };
+    ParDBThread<ParDB> db1 { db1_addr };
+    ParDBClient c1 { db1_addr };
+
+    elga::ZMQAddress db2_addr { "127.0.0.1", g_idx+=inc_amount };
+    ParDBThread<ParDB> db2 { db2_addr };
+    ParDBClient c2 { db2_addr };
+
+    c1.add_neighbor(db2_addr);
+    this_thread::sleep_for(chrono::milliseconds(50));
+    EQ(c1.num_neighbors(), 2);
+    
+    c1.import_db(data_dir);
+    this_thread::sleep_for(chrono::milliseconds(100));
+
+    EQ(c1.db_size() + c2.db_size(), 11);
+
+
+    TEST_PASS
+}
+
 TESTS_BEGIN
     elga::ZMQChatterbox::Setup();
 
@@ -1101,6 +1123,7 @@ TESTS_BEGIN
     RUN_TEST(subscribe_to_entry_multiple)
     RUN_TEST(get_entry_by_key)
     RUN_TEST(get_entry_by_key_multiple)
+    RUN_TEST(import_txt_db)
 
 
     elga::ZMQChatterbox::Teardown();


### PR DESCRIPTION
This adds the ability to ingest a directory of txt files in the form:

```
TAGS
BTC
block
VALUE
{ ... }
END
```

We should modify this to use Pigo, I need help with that though.